### PR TITLE
[DOC] typo on TARGET_LINUX_GENERATE_UIMAGE

### DIFF
--- a/doc/alchemy.html
+++ b/doc/alchemy.html
@@ -215,7 +215,7 @@ only the copy in build directory is modified, the original one is not touched.
 <li><code>TARGET_LINUX_DEVICE_TREE</code> : name of a device tree to append to kernel image.
 It shall be in <code>$(LINUX_BUILD_DIR)/arch/$(TARGET_ARCH)/boot/dts</code>. The name
 shall be the one with the <code>.dtb</code> extension. Default is empty.</li>
-<li><code>TARGET_GENERATE_LINUX_UIMAGE</code> : generate a u-boot image of linux.
+<li><code>TARGET_LINUX_GENERATE_UIMAGE</code> : generate a u-boot image of linux.
 </br>Default is <code>0</code></li>
 </ul>
 

--- a/doc/alchemy.mkd
+++ b/doc/alchemy.mkd
@@ -191,7 +191,7 @@ conflict with other build systems (android for example).
 * `TARGET_LINUX_DEVICE_TREE` : name of a device tree to append to kernel image.
   It shall be in `$(LINUX_BUILD_DIR)/arch/$(TARGET_ARCH)/boot/dts`. The name
   shall be the one with the `.dtb` extension. Default is empty.
-* `TARGET_GENERATE_LINUX_UIMAGE` : generate a u-boot image of linux.
+* `TARGET_LINUX_GENERATE_UIMAGE` : generate a u-boot image of linux.
   </br>Default is `0`
 
 ### Darwin specific


### PR DESCRIPTION
was erroneously referred as
TARGET_GENERATE_LINUX_UIMAGE